### PR TITLE
Add lodash.assign as dependency to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/quertt/markdown-it-asciimath#readme",
   "dependencies": {
-    "katex": "^0.7.1"
+    "katex": "^0.7.1",
+    "lodash.assign": "^4.2.0"
   }
 }


### PR DESCRIPTION
First off, thanks for this useful markdown-it extension.

I noticed that in

https://github.com/quertt/markdown-it-asciimath/blob/15a344b847edab4024c98e4a6de3e14239a1215d/index.js#L8

[`lodash.assign`](https://www.npmjs.com/package/lodash.assign) is imported, but never declared as dependency in the `package.json`

https://github.com/quertt/markdown-it-asciimath/blob/15a344b847edab4024c98e4a6de3e14239a1215d/package.json#L25-L27

for those of us installing via a package manager.