### PR TITLE
Update KaTeX (closes #5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ markdown-it-asciimath converts ASCII-math to TeX and then uses KaTeX to render t
 The plugin uses KaTeX to render TeX-math so the KaTeX stylesheet needs to be included:
 
 ```html
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.7.1/katex.min.css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.10.0/katex.min.css">
 ```
 
 To use the plugin:

--- a/index.js
+++ b/index.js
@@ -36,9 +36,6 @@ function setup(md, options) {
   md.renderer.rules.code_inline = function(tokens, idx, options, env, self) {
     var token = tokens[idx];
 
-    console.log(token.content.substr(0,4));
-    console.log(token.content.substr(4).trim());
-
     if(!useKeyword) {
       return renderInline(token.content.trim(), false);
     } else {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/quertt/markdown-it-asciimath#readme",
   "dependencies": {
-    "katex": "^0.7.1",
+    "katex": "^0.10.0",
     "lodash.assign": "^4.2.0"
   }
 }


### PR DESCRIPTION
Updating KaTeX to the latest version (0.10.0) fixes matrices and underbraces, at least for me:

```
ubrace(1+2+3+4)_("4 terms")
```

results in

![screenshot from 2018-11-11 22-29-08](https://user-images.githubusercontent.com/2021487/48318432-3f877d80-e601-11e8-9a3a-e52f52a70ee6.png)

This closes #5.